### PR TITLE
Update `@lblod/ldes-producer` to version 0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@lblod/ldes-producer": "^0.7.0",
+        "@lblod/ldes-producer": "^0.7.2",
         "body-parser": "^1.20.3"
       }
     },
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@lblod/ldes-producer": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@lblod/ldes-producer/-/ldes-producer-0.7.0.tgz",
-      "integrity": "sha512-V18FmvRfRjSa5BFsr2pLfoe+4g3hUxsWniq7p5Ad2EbL7vLzBcUUXZjZazzxe/3baf+ETTLc3VCmTGSndPzL6g==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@lblod/ldes-producer/-/ldes-producer-0.7.2.tgz",
+      "integrity": "sha512-9fsCmP86U96r74vAAurNe89QISliPBuZ/MozJrZLvfLIWb91Kq4I18VxbSjh9z5EjedzotHn7qhCB6haSN90Ag==",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/data-model": "~1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@lblod/ldes-producer": "^0.7.0",
+    "@lblod/ldes-producer": "^0.7.2",
     "body-parser": "^1.20.3"
   }
 }


### PR DESCRIPTION
This PR updates the `@lblod/ldes-producer` to version 0.7.2.
This version includes:
- a caching fix
- a change to the default data folder

I tested this PR in the https://github.com/lblod/app-mow-registry application.