### PR TITLE
fix missing trailing slash

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,15 @@ app.use(
     },
   })
 );
+
+if (!process.env.BASE_UR) {
+  throw new Error('Please set the "BASE_URL" environment variable');
+}
+
+if (!process.env.BASE_URL.endsWith("/")) {
+  process.env.BASE_URL += "/";
+}
+
 const config = getConfigFromEnv();
 
 app.get('/:folder*/:nodeId', async function (req, res, next) {

--- a/app.js
+++ b/app.js
@@ -16,7 +16,7 @@ app.use(
   })
 );
 
-if (!process.env.BASE_UR) {
+if (!process.env.BASE_URL) {
   throw new Error('Please set the "BASE_URL" environment variable');
 }
 


### PR DESCRIPTION
if the trailing slash is missing when setting the BASE_URL, the url will not be build correctly.
Applying the same logic as for the ldes delta pusher to solve the issue:
https://github.com/redpencilio/ldes-delta-pusher-service/blob/master/environment.ts#L27