### PR TITLE
Add support for basic auth

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,30 @@ if (!process.env.BASE_URL.endsWith("/")) {
 
 const config = getConfigFromEnv();
 
+
+
+const ENABLE_BASIC_AUTH = process.env.ENABLE_BASIC_AUTH === 'true' ? true : false;
+const BASIC_AUTH_USERNAME = process.env.BASIC_AUTH_USERNAME || 'username';
+const BASIC_AUTH_PASSWORD = process.env.BASIC_AUTH_PASSWORD || 'password';
+
+const basicAuthMiddleware = (req, res, next) => {
+  if (ENABLE_BASIC_AUTH) {
+    if (req.headers.authorization?.startsWith('Basic ')) {
+      const b64value = req.headers.authorization.split(' ')[1];
+      const [username, password] = Buffer.from(b64value, 'base64')
+        .toString()
+        .split(':');
+      if (username === BASIC_AUTH_USERNAME && password === BASIC_AUTH_PASSWORD) {
+        return next();
+      }
+    }
+    return res.status(401).send('Authentication failed.');
+  }
+  return next();
+};
+
+app.use(basicAuthMiddleware);
+
 app.get('/*', async function (req, res, next) {
   try {
     const contentType = req.accepts(ACCEPTED_CONTENT_TYPES) || '';

--- a/app.js
+++ b/app.js
@@ -37,6 +37,9 @@ const basicAuthMiddleware = (req, res, next) => {
   if(!folder){
     res.status(404).send();
   }
+  // Checks whether `ENABLE_BASIC_AUTH` is true and either:
+  // - `BASIC_AUTH_FOLDERS` is not provided: all folders/feeds are protected
+  // - `BASIC_AUTH_FOLDERS` is provided and the requested folder is in it
   const shouldUseBasicAuth = ENABLE_BASIC_AUTH && (!BASIC_AUTH_FOLDERS || BASIC_AUTH_FOLDERS.includes(folder));
   if (shouldUseBasicAuth) {
     if (req.headers.authorization?.startsWith('Basic ')) {

--- a/app.js
+++ b/app.js
@@ -26,14 +26,19 @@ if (!process.env.BASE_URL.endsWith("/")) {
 
 const config = getConfigFromEnv();
 
-
-
 const ENABLE_BASIC_AUTH = process.env.ENABLE_BASIC_AUTH === 'true' ? true : false;
 const BASIC_AUTH_USERNAME = process.env.BASIC_AUTH_USERNAME || 'username';
 const BASIC_AUTH_PASSWORD = process.env.BASIC_AUTH_PASSWORD || 'password';
+const BASIC_AUTH_FOLDERS = process.env.BASIC_AUTH_FOLDERS && JSON.parse(process.env.BASIC_AUTH_FOLDERS);
 
 const basicAuthMiddleware = (req, res, next) => {
-  if (ENABLE_BASIC_AUTH) {
+  const segments = req.params[0]?.split('/');
+  const folder = segments?.[0];
+  if(!folder){
+    res.status(404).send();
+  }
+  const shouldUseBasicAuth = ENABLE_BASIC_AUTH && (!BASIC_AUTH_FOLDERS || BASIC_AUTH_FOLDERS.includes(folder));
+  if (shouldUseBasicAuth) {
     if (req.headers.authorization?.startsWith('Basic ')) {
       const b64value = req.headers.authorization.split(' ')[1];
       const [username, password] = Buffer.from(b64value, 'base64')
@@ -48,9 +53,7 @@ const basicAuthMiddleware = (req, res, next) => {
   return next();
 };
 
-app.use(basicAuthMiddleware);
-
-app.get('/*', async function (req, res, next) {
+app.get('/*', basicAuthMiddleware, async function (req, res, next) {
   try {
     const contentType = req.accepts(ACCEPTED_CONTENT_TYPES) || '';
 


### PR DESCRIPTION
### Overview
This PR adds support for basic auth through the the following environment variables:
- `ENABLE_BASIC_AUTH`
- `BASIC_AUTH_USERNAME`
- `BASIC_AUTH_PASSWORD`
- `BASIC_AUTH_FOLDERS`: a list of folder/ldes feeds to apply basic auth for. If this environment variable is not provided, basic auth is applied to all feeds.


### How to test/reproduce
Check-out https://github.com/lblod/app-ipdc-ldes-mirror/pull/1 for an example and test instructions

### Challenges/uncertainties
- Unsure if the `BASIC_AUTH_FOLDERS` feature to selectively apply basic auth to certain feeds is desired/wanted.
In context of the IPDC feeds we would like to protect only the `feedbacksnapshots` feed with basic auth.
- Should we remove the default values for `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` to prevent accidents?